### PR TITLE
fix: 統計ダッシュボードの画像サムネイルが表示されない問題を修正

### DIFF
--- a/.ai-agent/tasks/20260124-fix-stats-thumbnail/README.md
+++ b/.ai-agent/tasks/20260124-fix-stats-thumbnail/README.md
@@ -1,0 +1,42 @@
+# 統計表示で画像サムネイルが表示されない
+
+Issue: https://github.com/mizunashi-mana/picstash/issues/64
+
+## 目的・ゴール
+
+統計ダッシュボードの「よく閲覧された画像」でサムネイルを正常に表示する。
+
+## 問題の原因
+
+`PopularImagesList.tsx` の `getThumbnailUrl` 関数で誤った URL パターンを使用:
+
+```typescript
+// 現在（誤り）
+return `/api/images/file/${encodeURIComponent(thumbnailPath)}`;
+
+// 正しいパターン（他コンポーネントと同様）
+return `/api/images/${imageId}/thumbnail`;
+```
+
+## 実装方針
+
+1. `PopularImagesList.tsx` の `getThumbnailUrl` を修正
+2. `thumbnailPath` ではなく `id` を使用して URL を生成
+
+## 完了条件
+
+- [x] サムネイルが正常に表示される
+- [x] 型チェックが通る
+- [x] リントが通る
+
+## 作業ログ
+
+### 2026-01-24
+
+1. 問題の原因を特定
+   - `PopularImagesList.tsx` で誤った URL パターンを使用
+   - `/api/images/file/${thumbnailPath}` → `/api/images/${id}/thumbnail` に修正
+
+2. 修正完了
+   - `getThumbnailUrl` 関数を修正
+   - 型チェック・リント通過

--- a/packages/web-client/src/features/stats/components/PopularImagesList.tsx
+++ b/packages/web-client/src/features/stats/components/PopularImagesList.tsx
@@ -23,11 +23,8 @@ function formatDate(dateStr: string | null): string {
   return date.toLocaleDateString('ja-JP');
 }
 
-function getThumbnailUrl(thumbnailPath: string | null): string {
-  if (thumbnailPath === null) {
-    return '';
-  }
-  return `/api/images/file/${encodeURIComponent(thumbnailPath)}`;
+function getThumbnailUrl(imageId: string): string {
+  return `/api/images/${imageId}/thumbnail`;
 }
 
 export function PopularImagesList({ images }: PopularImagesListProps) {
@@ -56,7 +53,7 @@ export function PopularImagesList({ images }: PopularImagesListProps) {
                     {index + 1}
                   </Text>
                   <Image
-                    src={getThumbnailUrl(image.thumbnailPath)}
+                    src={getThumbnailUrl(image.id)}
                     alt={image.title}
                     w={60}
                     h={60}


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

統計ダッシュボードの「よく閲覧された画像」セクションでサムネイルが表示されない問題を修正する。

Fixes #64

## 変更概要

- `PopularImagesList.tsx` の `getThumbnailUrl` 関数を修正
- 誤った URL パターン `/api/images/file/${thumbnailPath}` を正しいパターン `/api/images/${id}/thumbnail` に変更
- 他のコンポーネント（ギャラリー、コレクション等）と同じ URL パターンに統一

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)