### PR TITLE
test: テストカバレッジチェックのignoreを削減

### DIFF
--- a/.ai-agent/tasks/20260124-reduce-coverage-ignore/README.md
+++ b/.ai-agent/tasks/20260124-reduce-coverage-ignore/README.md
@@ -1,0 +1,90 @@
+# テストカバレッジチェックのignore削減
+
+## 目的・ゴール
+
+現在、vitest のカバレッジ設定で多くのファイル・ディレクトリが exclude されている。
+テスト未実装を理由に除外されているファイルにテストを追加し、exclude リストを削減する。
+
+## 現状
+
+### packages/server/vitest.config.ts
+
+除外対象:
+- エントリーポイント・CLI: `src/index.ts`, `src/app.ts`, `src/config.ts`, `src/cli/**/*.ts`
+- インフラ層: `src/infra/di/**`, `database/**`, `http/**`, `queue/**`, `storage/**`, `workers/**`, `adapters/**`, `embedding/**`
+- アプリケーション層: `src/application/image/**`, `image-attribute/**`, `label/**`, `url-crawl/**`, `ports/**`, `embedding/**`, `attribute-suggestion/**`, `archive/**`, `recommendation/**`
+- ドメイン層: `src/domain/collection/**`, `image-attribute/**`, 一部個別ファイル
+- 共有モジュール: `src/shared/**/*.ts`
+- インデックスファイル: `src/**/index.ts`
+
+### packages/web-client/vitest.config.ts
+
+除外対象:
+- エントリーポイント: `src/main.tsx`, `src/vite-env.d.ts`
+- Storybook: `src/**/*.stories.tsx`
+- 全 feature: `src/features/**/*.{ts,tsx}` (大きな範囲)
+- API クライアント: `src/api/**/*.ts`
+- ルーティング: `src/routes/**/*.tsx`
+- 共有コンポーネント: `src/shared/**/*.{ts,tsx}`
+- App コンポーネント: `src/App.tsx`
+- インデックスファイル: `src/**/index.ts`
+
+## 実装方針
+
+1. **サーバー側ドメイン層のテスト追加** (優先度: 高)
+   - 除外されているがビジネスロジックを含むドメインファイルにテストを追加
+   - 例: `Image.ts`, `Label.ts`, `UrlCrawlConfig.ts` など
+
+2. **サーバー側アプリケーション層の単純なユースケースにテスト追加** (優先度: 中)
+   - 外部依存が少なく、モックしやすいユースケースから着手
+
+3. **Web クライアント側のユーティリティ関数にテスト追加** (優先度: 中)
+   - `shared/helpers/` 内のユーティリティ関数からテストを追加
+
+4. **テスト追加後、対応する exclude を削除**
+
+## 完了条件
+
+- [x] vitest.config.ts の exclude リストが現状より少なくなっている
+- [x] 追加したテストがすべてパスする
+- [x] カバレッジ閾値（80%）を満たしている
+- [x] `npm run test:coverage` が成功する
+
+## 作業ログ
+
+### 2026-01-24
+
+#### 追加したテスト
+
+1. **server: HtmlImageExtractor.ts** (34 tests)
+   - `tests/domain/url-crawl/html-image-extractor.test.ts` を新規作成
+   - `extractImageUrls`, `extractPageTitle`, `filterImageEntries` のテストを追加
+   - カバレッジ: lines 97.29%, branches 91.42%
+
+2. **server: UrlCrawlConfig.ts の追加テスト** (8 tests)
+   - `tests/domain/url-crawl/url-crawl-config.test.ts` に追加
+   - `isSupportedImageExtension`, `getMimeTypeFromExtension`, `isImageUrl` (エッジケース), `extractFilenameFromUrl` (エッジケース) のテストを追加
+
+3. **web-client: buildUrl ヘルパー** (14 tests)
+   - `tests/helpers/url.test.ts` を新規作成
+   - カバレッジ: 100%
+
+#### 除外リストから削除したファイル
+
+**packages/server/vitest.config.ts:**
+- `src/domain/url-crawl/HtmlImageExtractor.ts` - テスト追加により削除
+
+**packages/web-client/vitest.config.ts:**
+- `src/shared/**/*.{ts,tsx}` → `src/shared/components/**/*.{ts,tsx}` と `src/shared/hooks/**/*.{ts,tsx}` に限定
+  - これにより `src/shared/helpers/url.ts` がカバレッジ対象に
+
+#### 除外リストに残したファイル
+
+- `src/domain/url-crawl/UrlCrawlConfig.ts`: `??` 演算子の到達困難な分岐により branch 閾値 80% 未満
+- 型定義のみのファイル（interface）: テスト対象外
+  - `CrawledImageEntry.ts`, `UrlCrawlSession.ts`, `ArchiveEntry.ts`, `ArchiveSession.ts`
+
+#### 結果
+
+- server: 306 tests passed, カバレッジ 97.94%
+- web-client: 15 tests passed, カバレッジ 100%

--- a/packages/server/tests/domain/url-crawl/html-image-extractor.test.ts
+++ b/packages/server/tests/domain/url-crawl/html-image-extractor.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractImageUrls,
+  extractPageTitle,
+  filterImageEntries,
+} from '@/domain/url-crawl/HtmlImageExtractor.js';
+import type { CrawledImageEntry } from '@/domain/url-crawl/CrawledImageEntry.js';
+
+describe('HtmlImageExtractor', () => {
+  describe('extractImageUrls', () => {
+    const baseUrl = 'https://example.com/page/';
+
+    describe('img tags', () => {
+      it('should extract image URL from basic img tag', () => {
+        const html = '<img src="image.jpg">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          index: 0,
+          url: 'https://example.com/page/image.jpg',
+          filename: 'image.jpg',
+        });
+      });
+
+      it('should extract alt text from img tag', () => {
+        const html = '<img src="image.jpg" alt="A beautiful sunset">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.alt).toBe('A beautiful sunset');
+      });
+
+      it('should handle img tag with alt before src', () => {
+        const html = '<img alt="Description" src="photo.png">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          url: 'https://example.com/page/photo.png',
+          alt: 'Description',
+        });
+      });
+
+      it('should handle absolute URLs', () => {
+        const html = '<img src="https://cdn.example.com/images/logo.png">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.url).toBe('https://cdn.example.com/images/logo.png');
+      });
+
+      it('should handle root-relative URLs', () => {
+        const html = '<img src="/assets/image.jpg">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.url).toBe('https://example.com/assets/image.jpg');
+      });
+
+      it('should skip img tags without src', () => {
+        const html = '<img alt="No source">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(0);
+      });
+
+      it('should skip empty alt text', () => {
+        const html = '<img src="image.jpg" alt="">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.alt).toBeUndefined();
+      });
+
+      it('should deduplicate identical URLs', () => {
+        const html = `
+          <img src="same.jpg">
+          <img src="same.jpg">
+          <img src="different.jpg">
+        `;
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(2);
+      });
+    });
+
+    describe('link tags', () => {
+      it('should extract image URLs from anchor tags', () => {
+        const html = '<a href="photo.jpg">View photo</a>';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.url).toBe('https://example.com/page/photo.jpg');
+      });
+
+      it('should only extract links with image extensions', () => {
+        const html = `
+          <a href="image.png">Image</a>
+          <a href="document.pdf">PDF</a>
+          <a href="page.html">Page</a>
+        `;
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('image.png');
+      });
+    });
+
+    describe('background images', () => {
+      it('should extract background-image URLs', () => {
+        const html = '<div style="background-image: url(\'bg.jpg\')"></div>';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('bg.jpg');
+      });
+
+      it('should extract background URLs with double quotes', () => {
+        const html = '<div style="background: url(\'pattern.png\')"></div>';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('pattern.png');
+      });
+
+      it('should extract background URLs without quotes', () => {
+        const html = '<div style="background-image: url(texture.gif)"></div>';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('texture.gif');
+      });
+    });
+
+    describe('srcset', () => {
+      const getFilename = (e: { filename: string }): string => e.filename;
+
+      it('should extract URLs from srcset attribute', () => {
+        const html = '<img srcset="small.jpg 1x, large.jpg 2x">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(2);
+        const filenames = result.map(getFilename);
+        expect(filenames).toContain('small.jpg');
+        expect(filenames).toContain('large.jpg');
+      });
+
+      it('should extract URLs from srcset with width descriptors', () => {
+        const html = '<img srcset="mobile.jpg 480w, desktop.jpg 1200w">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(2);
+      });
+    });
+
+    describe('data-src (lazy loading)', () => {
+      it('should extract data-src URLs', () => {
+        const html = '<img data-src="lazy.jpg">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('lazy.jpg');
+      });
+
+      it('should extract data-original URLs', () => {
+        const html = '<img data-original="original.png">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('original.png');
+      });
+
+      it('should extract data-lazy URLs', () => {
+        const html = '<img data-lazy="lazy-loaded.webp">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(1);
+        expect(result[0]?.filename).toBe('lazy-loaded.webp');
+      });
+    });
+
+    describe('URL resolution', () => {
+      it('should skip fragment-only URLs', () => {
+        const html = '<img src="#anchor">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(0);
+      });
+
+      it('should skip non-http protocols', () => {
+        const html = `
+          <img src="data:image/png;base64,abc123">
+          <img src="javascript:void(0)">
+          <img src="file:///etc/passwd">
+        `;
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(0);
+      });
+
+      it('should handle truly malformed URLs gracefully', () => {
+        // Note: '://invalid-url' gets resolved to 'https://invalid-url' by URL API
+        // Test with a URL that actually throws
+        const html = '<img src="">';
+        const result = extractImageUrls(html, baseUrl);
+        expect(result).toHaveLength(0);
+      });
+    });
+
+    describe('limit', () => {
+      it('should limit the number of images to MAX_IMAGES_PER_PAGE (500)', () => {
+        const generateImgTag = (_: unknown, i: number): string => `<img src="image${i}.jpg">`;
+        const images = Array.from({ length: 600 }, generateImgTag);
+        const html = images.join('\n');
+        const result = extractImageUrls(html, baseUrl);
+        expect(result.length).toBeLessThanOrEqual(500);
+        expect(result).toHaveLength(500);
+      });
+    });
+
+    describe('combined extraction', () => {
+      it('should extract images from multiple sources', () => {
+        const html = `
+          <html>
+            <head><title>Gallery</title></head>
+            <body>
+              <img src="main.jpg" alt="Main image">
+              <a href="full.png">Full size</a>
+              <div style="background-image: url('bg.gif')"></div>
+              <img srcset="thumb.jpg 1x, large.jpg 2x">
+              <img data-src="lazy.webp">
+            </body>
+          </html>
+        `;
+        const result = extractImageUrls(html, baseUrl);
+        // main.jpg, full.png, bg.gif, thumb.jpg, large.jpg, lazy.webp = 6
+        expect(result.length).toBeGreaterThanOrEqual(6);
+      });
+    });
+  });
+
+  describe('extractPageTitle', () => {
+    it('should extract page title', () => {
+      const html = '<html><head><title>My Gallery</title></head></html>';
+      const result = extractPageTitle(html);
+      expect(result).toBe('My Gallery');
+    });
+
+    it('should trim whitespace from title', () => {
+      const html = '<title>  Spaced Title  </title>';
+      const result = extractPageTitle(html);
+      expect(result).toBe('Spaced Title');
+    });
+
+    it('should return undefined for missing title', () => {
+      const html = '<html><head></head></html>';
+      const result = extractPageTitle(html);
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle title with attributes', () => {
+      const html = '<title lang="en">English Title</title>';
+      const result = extractPageTitle(html);
+      expect(result).toBe('English Title');
+    });
+  });
+
+  describe('filterImageEntries', () => {
+    it('should filter entries to only supported image formats', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'https://example.com/image.jpg', filename: 'image.jpg' },
+        { index: 1, url: 'https://example.com/photo.png', filename: 'photo.png' },
+        { index: 2, url: 'https://example.com/video.mp4', filename: 'video.mp4' },
+        { index: 3, url: 'https://example.com/doc.pdf', filename: 'doc.pdf' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(2);
+      expect(result.map(e => e.filename)).toEqual(['image.jpg', 'photo.png']);
+    });
+
+    it('should re-index entries after filtering', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'https://example.com/doc.pdf', filename: 'doc.pdf' },
+        { index: 1, url: 'https://example.com/image.jpg', filename: 'image.jpg' },
+        { index: 2, url: 'https://example.com/photo.png', filename: 'photo.png' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(2);
+      expect(result[0]?.index).toBe(0);
+      expect(result[1]?.index).toBe(1);
+    });
+
+    it('should support various image extensions', () => {
+      // Supported extensions from UrlCrawlConfig: .jpg, .jpeg, .png, .gif, .webp, .bmp
+      const extensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'];
+      const entries: CrawledImageEntry[] = extensions.map((ext, i) => ({
+        index: i,
+        url: `https://example.com/image${ext}`,
+        filename: `image${ext}`,
+      }));
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(extensions.length);
+    });
+
+    it('should handle URLs with query parameters', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'https://example.com/image.jpg?size=large', filename: 'image.jpg' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should handle invalid URLs gracefully', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'not-a-valid-url', filename: 'invalid' },
+        { index: 1, url: 'https://example.com/valid.jpg', filename: 'valid.jpg' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.filename).toBe('valid.jpg');
+    });
+
+    it('should be case-insensitive for extensions', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'https://example.com/image.JPG', filename: 'image.JPG' },
+        { index: 1, url: 'https://example.com/photo.PNG', filename: 'photo.PNG' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array for no valid images', () => {
+      const entries: CrawledImageEntry[] = [
+        { index: 0, url: 'https://example.com/doc.pdf', filename: 'doc.pdf' },
+        { index: 1, url: 'https://example.com/video.mp4', filename: 'video.mp4' },
+      ];
+      const result = filterImageEntries(entries);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/packages/server/tests/domain/url-crawl/url-crawl-config.test.ts
+++ b/packages/server/tests/domain/url-crawl/url-crawl-config.test.ts
@@ -4,6 +4,8 @@ import {
   getExtensionFromContentType,
   isImageUrl,
   extractFilenameFromUrl,
+  isSupportedImageExtension,
+  getMimeTypeFromExtension,
 } from '@/domain/url-crawl/index.js';
 
 describe('isImageContentType', () => {
@@ -113,5 +115,65 @@ describe('extractFilenameFromUrl', () => {
 
   it('should return default for URLs without filename', () => {
     expect(extractFilenameFromUrl('https://example.com/')).toBe('image');
+  });
+
+  it('should return default for invalid URLs', () => {
+    expect(extractFilenameFromUrl('not-a-valid-url')).toBe('image');
+  });
+});
+
+describe('isSupportedImageExtension', () => {
+  it('should return true for supported extensions', () => {
+    expect(isSupportedImageExtension('.jpg')).toBe(true);
+    expect(isSupportedImageExtension('.jpeg')).toBe(true);
+    expect(isSupportedImageExtension('.png')).toBe(true);
+    expect(isSupportedImageExtension('.gif')).toBe(true);
+    expect(isSupportedImageExtension('.webp')).toBe(true);
+    expect(isSupportedImageExtension('.bmp')).toBe(true);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isSupportedImageExtension('.JPG')).toBe(true);
+    expect(isSupportedImageExtension('.PNG')).toBe(true);
+    expect(isSupportedImageExtension('.Gif')).toBe(true);
+  });
+
+  it('should return false for unsupported extensions', () => {
+    expect(isSupportedImageExtension('.tiff')).toBe(false);
+    expect(isSupportedImageExtension('.svg')).toBe(false);
+    expect(isSupportedImageExtension('.heic')).toBe(false);
+    expect(isSupportedImageExtension('.avif')).toBe(false);
+    expect(isSupportedImageExtension('.pdf')).toBe(false);
+    expect(isSupportedImageExtension('')).toBe(false);
+  });
+});
+
+describe('getMimeTypeFromExtension', () => {
+  it('should return correct MIME type for supported extensions', () => {
+    expect(getMimeTypeFromExtension('.jpg')).toBe('image/jpeg');
+    expect(getMimeTypeFromExtension('.jpeg')).toBe('image/jpeg');
+    expect(getMimeTypeFromExtension('.png')).toBe('image/png');
+    expect(getMimeTypeFromExtension('.gif')).toBe('image/gif');
+    expect(getMimeTypeFromExtension('.webp')).toBe('image/webp');
+    expect(getMimeTypeFromExtension('.bmp')).toBe('image/bmp');
+  });
+
+  it('should be case-insensitive', () => {
+    expect(getMimeTypeFromExtension('.JPG')).toBe('image/jpeg');
+    expect(getMimeTypeFromExtension('.PNG')).toBe('image/png');
+  });
+
+  it('should return octet-stream for unsupported extensions', () => {
+    expect(getMimeTypeFromExtension('.tiff')).toBe('application/octet-stream');
+    expect(getMimeTypeFromExtension('.svg')).toBe('application/octet-stream');
+    expect(getMimeTypeFromExtension('.pdf')).toBe('application/octet-stream');
+    expect(getMimeTypeFromExtension('')).toBe('application/octet-stream');
+  });
+});
+
+describe('isImageUrl - edge cases', () => {
+  it('should return false for invalid URLs', () => {
+    expect(isImageUrl('not-a-valid-url')).toBe(false);
+    expect(isImageUrl('')).toBe(false);
   });
 });

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -49,12 +49,13 @@ export default defineConfig({
         'src/domain/search-history/**/*.ts',
         'src/domain/stats/**/*.ts',
         'src/domain/view-history/**/*.ts',
+        // 型定義のみ（interface）: テスト対象外
         'src/domain/url-crawl/CrawledImageEntry.ts',
-        'src/domain/url-crawl/HtmlImageExtractor.ts',
         'src/domain/url-crawl/UrlCrawlSession.ts',
-        'src/domain/url-crawl/UrlCrawlConfig.ts',
         'src/domain/archive/ArchiveEntry.ts',
         'src/domain/archive/ArchiveSession.ts',
+        // ?? 演算子の到達困難な分岐により branch 閾値 80% 未満
+        'src/domain/url-crawl/UrlCrawlConfig.ts',
         // 共有モジュール（テスト未実装）
         'src/shared/**/*.ts',
         // インデックスファイル

--- a/packages/web-client/tests/helpers/url.test.ts
+++ b/packages/web-client/tests/helpers/url.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { buildUrl } from '@/shared/helpers/url';
+
+describe('buildUrl', () => {
+  it('should return path as-is when no params provided', () => {
+    expect(buildUrl('/images')).toBe('/images');
+  });
+
+  it('should return path as-is when params is undefined', () => {
+    expect(buildUrl('/images', undefined)).toBe('/images');
+  });
+
+  it('should build URL with single parameter', () => {
+    const result = buildUrl('/images', { q: 'search' });
+    expect(result).toBe('/images?q=search');
+  });
+
+  it('should build URL with multiple parameters', () => {
+    const result = buildUrl('/images', { q: 'search', limit: 50 });
+    expect(result).toBe('/images?q=search&limit=50');
+  });
+
+  it('should filter out undefined values', () => {
+    const result = buildUrl('/images', { q: 'search', filter: undefined });
+    expect(result).toBe('/images?q=search');
+  });
+
+  it('should filter out null values', () => {
+    const result = buildUrl('/images', { q: 'search', filter: null });
+    expect(result).toBe('/images?q=search');
+  });
+
+  it('should return path only when all params are undefined or null', () => {
+    const result = buildUrl('/images', { q: undefined, filter: null });
+    expect(result).toBe('/images');
+  });
+
+  it('should handle boolean parameters', () => {
+    const result = buildUrl('/images', { featured: true, archived: false });
+    expect(result).toBe('/images?featured=true&archived=false');
+  });
+
+  it('should handle number parameters', () => {
+    const result = buildUrl('/images', { page: 1, limit: 20 });
+    expect(result).toBe('/images?page=1&limit=20');
+  });
+
+  it('should encode special characters', () => {
+    const result = buildUrl('/images', { q: 'hello world' });
+    expect(result).toBe('/images?q=hello%20world');
+  });
+
+  it('should handle empty string parameter', () => {
+    const result = buildUrl('/images', { q: '' });
+    expect(result).toBe('/images?q=');
+  });
+
+  it('should handle mixed valid and undefined parameters', () => {
+    const result = buildUrl('/images', {
+      q: 'test',
+      page: 1,
+      filter: undefined,
+      sort: 'date',
+      order: null,
+    });
+    expect(result).toBe('/images?q=test&page=1&sort=date');
+  });
+
+  it('should handle path with trailing slash', () => {
+    const result = buildUrl('/api/images/', { limit: 10 });
+    expect(result).toBe('/api/images/?limit=10');
+  });
+
+  it('should handle empty params object', () => {
+    const result = buildUrl('/images', {});
+    expect(result).toBe('/images');
+  });
+});

--- a/packages/web-client/vitest.config.ts
+++ b/packages/web-client/vitest.config.ts
@@ -59,8 +59,9 @@ export default defineConfig({
         'src/api/**/*.ts',
         // ルーティング
         'src/routes/**/*.tsx',
-        // 共有コンポーネント（テスト未実装）
-        'src/shared/**/*.{ts,tsx}',
+        // 共有コンポーネント・フック（テスト未実装）
+        'src/shared/components/**/*.{ts,tsx}',
+        'src/shared/hooks/**/*.{ts,tsx}',
         // App コンポーネント
         'src/App.tsx',
         // インデックスファイル


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

vitest のカバレッジ設定で多くのファイル・ディレクトリが exclude されている状況を改善し、テストカバレッジの可視性を向上させる。

## 変更概要

### 追加したテスト

- **server: HtmlImageExtractor.ts** (34 tests)
  - `extractImageUrls`, `extractPageTitle`, `filterImageEntries` のテストを追加
  - カバレッジ: lines 97.29%, branches 91.42%

- **server: UrlCrawlConfig.ts** (8 tests 追加)
  - `isSupportedImageExtension`, `getMimeTypeFromExtension`, エッジケースのテストを追加

- **web-client: buildUrl ヘルパー** (14 tests)
  - `shared/helpers/url.ts` のテストを新規作成
  - カバレッジ: 100%

### 除外リストから削除したファイル

- **server:** `HtmlImageExtractor.ts`
- **web-client:** `shared/helpers/url.ts` (`shared/**` → `shared/components/**` と `shared/hooks/**` に限定)

### 最終カバレッジ

- **server:** 306 tests passed, カバレッジ 97.94%
- **web-client:** 15 tests passed, カバレッジ 100%

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)