### PR TITLE
feat: Config を DI コンテナ経由で注入する形式に移行

### DIFF
--- a/.ai-agent/tasks/20260125-migrate-config-to-di/README.md
+++ b/.ai-agent/tasks/20260125-migrate-config-to-di/README.md
@@ -1,0 +1,48 @@
+# 設定読み込みをグローバル変数から DI パターンに移行
+
+## 目的・ゴール
+
+設定の読み込みをグローバル変数から DI パターンに移行し、テスタビリティと保守性を向上させる。
+
+## 背景
+
+現在の問題:
+- グローバル状態のためモックが難しい
+- テスト間で状態が共有されてしまう
+- どのモジュールがどの設定を使用しているか追いにくい
+
+## 現状分析
+
+`getConfig()` の使用箇所:
+1. `index.ts` - エントリポイント（これは OK）
+2. `infra/adapters/sharp-image-processor.ts` - storagePath を取得
+3. `infra/di/container.ts` - ollama の設定確認
+4. `infra/llm/ollama-llm-service.ts` - ollama URL/モデル取得
+5. `infra/adapters/local-file-storage.ts` - storagePath を取得
+6. `infra/adapters/in-memory-archive-session-manager.ts` - storagePath を取得
+
+## 実装方針
+
+1. **Config を DI コンテナに登録**
+   - `TYPES.Config` を追加
+   - `container.ts` で Config をバインド
+
+2. **各サービスでコンストラクタ注入**
+   - `@inject(TYPES.Config)` でコンストラクタに注入
+   - `getConfig()` の直接呼び出しを削除
+
+3. **グローバル変数の廃止**
+   - `loadedConfig` を削除
+   - `initConfig` で設定を読み込み、コンテナに渡す
+
+## 完了条件
+
+- [ ] Config が DI コンテナに登録されている
+- [ ] 全サービスがコンストラクタ注入で Config を受け取る
+- [ ] `getConfig()` のグローバル呼び出しがなくなる
+- [ ] テストが通る
+- [ ] ビルドが成功する
+
+## 作業ログ
+
+（作業中に更新）

--- a/packages/server/src/cli/generate-embeddings.ts
+++ b/packages/server/src/cli/generate-embeddings.ts
@@ -17,12 +17,12 @@ import {
   syncEmbeddingsToVectorDb,
   type GenerateEmbeddingDeps,
 } from '@/application/embedding/generate-embedding.js';
-import { initConfig, parseCliArgs } from '@/config.js';
+import { type Config, initConfig, parseCliArgs } from '@/config.js';
 import { connectDatabase, disconnectDatabase } from '@/infra/database/prisma.js';
 import { buildAppContainer } from '@/infra/di/index.js';
 
-function getDeps(): GenerateEmbeddingDeps {
-  const container = buildAppContainer();
+function getDeps(config: Config): GenerateEmbeddingDeps {
+  const container = buildAppContainer(config);
   return {
     imageRepository: container.getImageRepository(),
     fileStorage: container.getFileStorage(),
@@ -35,12 +35,12 @@ async function main(): Promise<void> {
   const { command, configPath } = parseCliArgs(process.argv);
 
   // Initialize configuration
-  initConfig(configPath);
+  const config = initConfig(configPath);
 
   console.log('Connecting to database...');
   await connectDatabase();
 
-  const deps = getDeps();
+  const deps = getDeps(config);
 
   try {
     switch (command) {

--- a/packages/server/src/cli/generate-label-embeddings.ts
+++ b/packages/server/src/cli/generate-label-embeddings.ts
@@ -16,12 +16,12 @@ import {
   regenerateAllLabelEmbeddings,
   type GenerateLabelEmbeddingDeps,
 } from '@/application/attribute-suggestion/generate-label-embeddings.js';
-import { initConfig, parseCliArgs } from '@/config.js';
+import { type Config, initConfig, parseCliArgs } from '@/config.js';
 import { connectDatabase, disconnectDatabase } from '@/infra/database/prisma.js';
 import { buildAppContainer } from '@/infra/di/index.js';
 
-function getDeps(): GenerateLabelEmbeddingDeps {
-  const container = buildAppContainer();
+function getDeps(config: Config): GenerateLabelEmbeddingDeps {
+  const container = buildAppContainer(config);
   return {
     labelRepository: container.getLabelRepository(),
     embeddingService: container.getEmbeddingService(),
@@ -32,12 +32,12 @@ async function main(): Promise<void> {
   const { command, configPath } = parseCliArgs(process.argv);
 
   // Initialize configuration
-  initConfig(configPath);
+  const config = initConfig(configPath);
 
   console.log('Connecting to database...');
   await connectDatabase();
 
-  const deps = getDeps();
+  const deps = getDeps(config);
 
   try {
     switch (command) {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -73,8 +73,6 @@ const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>;
 
-let loadedConfig: Config | null = null;
-
 /**
  * Load configuration from a YAML file.
  * @param configPath - Path to the config file. If not provided, uses default path.
@@ -95,17 +93,7 @@ export function loadConfig(configPath?: string): Config {
  */
 export function initConfig(configPath?: string): Config {
   const path = configPath ?? process.env.PICSTASH_CONFIG ?? undefined;
-  loadedConfig = loadConfig(path);
-  return loadedConfig;
-}
-
-/**
- * Get the current configuration.
- * If not initialized, loads from default path or PICSTASH_CONFIG env var.
- */
-export function getConfig(): Config {
-  loadedConfig ??= loadConfig(process.env.PICSTASH_CONFIG ?? undefined);
-  return loadedConfig;
+  return loadConfig(path);
 }
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@
 // API サーバーのエントリポイント
 
 import { buildApp } from '@/app.js';
-import { getConfig, initConfig, parseConfigArg } from '@/config.js';
+import { initConfig, parseConfigArg } from '@/config.js';
 import { connectDatabase, disconnectDatabase } from '@/infra/database/prisma.js';
 import { buildAppContainer } from '@/infra/di/index.js';
 import { JobWorker } from '@/infra/queue/index.js';
@@ -11,10 +11,9 @@ import { createCaptionJobHandler, CAPTION_JOB_TYPE } from '@/infra/workers/index
 async function main(): Promise<void> {
   // Parse --config argument and initialize configuration
   const configPath = parseConfigArg(process.argv);
-  initConfig(configPath);
-  const config = getConfig();
+  const config = initConfig(configPath);
 
-  const container = buildAppContainer();
+  const container = buildAppContainer(config);
   const app = await buildApp(container, config);
 
   // Connect to database

--- a/packages/server/src/infra/di/app-container.ts
+++ b/packages/server/src/infra/di/app-container.ts
@@ -18,6 +18,7 @@ import type { SearchHistoryRepository } from '@/application/ports/search-history
 import type { StatsRepository } from '@/application/ports/stats-repository.js';
 import type { UrlCrawlSessionManager } from '@/application/ports/url-crawl-session-manager.js';
 import type { ViewHistoryRepository } from '@/application/ports/view-history-repository.js';
+import type { Config } from '@/config.js';
 import type {
   ArchiveController,
   CollectionController,
@@ -184,8 +185,9 @@ export class AppContainer {
 
 /**
  * Creates a new AppContainer instance with all dependencies configured.
+ * @param config - Application configuration
  */
-export function buildAppContainer(): AppContainer {
-  const container = createContainer();
+export function buildAppContainer(config: Config): AppContainer {
+  const container = createContainer(config);
   return new AppContainer(container);
 }

--- a/packages/server/src/infra/di/container.ts
+++ b/packages/server/src/infra/di/container.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 import { Container } from 'inversify';
-import { getConfig } from '@/config.js';
 import {
   InMemoryArchiveSessionManager,
   InMemoryUrlCrawlSessionManager,
@@ -57,12 +56,17 @@ import type { SearchHistoryRepository } from '@/application/ports/search-history
 import type { StatsRepository } from '@/application/ports/stats-repository.js';
 import type { UrlCrawlSessionManager } from '@/application/ports/url-crawl-session-manager.js';
 import type { ViewHistoryRepository } from '@/application/ports/view-history-repository.js';
+import type { Config } from '@/config.js';
 
 /**
  * Creates and configures a new inversify Container with all dependencies.
+ * @param config - Application configuration
  */
-export function createContainer(): Container {
+export function createContainer(config: Config): Container {
   const container = new Container();
+
+  // Bind config
+  container.bind<Config>(TYPES.Config).toConstantValue(config);
 
   // Bind repositories as singletons
   container
@@ -161,7 +165,6 @@ export function createContainer(): Container {
     .inSingletonScope();
 
   // Bind LLM service only if ollama is configured
-  const config = getConfig();
   if (config.ollama !== undefined) {
     container
       .bind<LlmService>(TYPES.LlmService)

--- a/packages/server/src/infra/di/types.ts
+++ b/packages/server/src/infra/di/types.ts
@@ -1,4 +1,7 @@
 export const TYPES = {
+  // Config
+  Config: Symbol.for('Config'),
+
   // Repositories
   ImageRepository: Symbol.for('ImageRepository'),
   LabelRepository: Symbol.for('LabelRepository'),

--- a/packages/server/src/infra/llm/ollama-llm-service.ts
+++ b/packages/server/src/infra/llm/ollama-llm-service.ts
@@ -6,13 +6,14 @@
  */
 
 import 'reflect-metadata';
-import { injectable } from 'inversify';
-import { getConfig } from '@/config.js';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '@/infra/di/types.js';
 import type {
   LlmService,
   LlmGenerateResult,
   LlmGenerateOptions,
 } from '@/application/ports/llm-service.js';
+import type { Config } from '@/config.js';
 
 /** Default Ollama API URL */
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
@@ -38,8 +39,7 @@ export class OllamaLlmService implements LlmService {
   private readonly baseUrl: string;
   private readonly model: string;
 
-  constructor() {
-    const config = getConfig();
+  constructor(@inject(TYPES.Config) config: Config) {
     this.baseUrl = config.ollama?.url ?? DEFAULT_OLLAMA_URL;
     this.model = config.ollama?.model ?? DEFAULT_MODEL;
   }


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

設定値をグローバル変数経由で取得する形式から、DI コンテナ経由でコンストラクタ注入する形式に移行します。これにより以下のメリットがあります:

- テスト時にモックが容易になる
- 依存関係が明示的になる
- グローバル状態への依存がなくなる

Closes #73

## 変更概要

### DI コンテナの変更
- `TYPES.Config` シンボルを追加
- `createContainer(config: Config)` が config を引数として受け取り、コンテナにバインド
- `buildAppContainer(config: Config)` も同様に config を引数として受け取る

### サービスのコンストラクタ注入化
以下のサービスを `getConfig()` 呼び出しから `@inject(TYPES.Config)` によるコンストラクタ注入に変更:
- `LocalFileStorage`
- `SharpImageProcessor`
- `InMemoryArchiveSessionManager`
- `OllamaLlmService`

### エントリポイントの更新
- `src/index.ts`: `initConfig()` の戻り値を `buildAppContainer()` に渡す
- `src/cli/generate-embeddings.ts`: 同様の変更
- `src/cli/generate-label-embeddings.ts`: 同様の変更

### グローバル変数の削除
- `config.ts` から `loadedConfig` グローバル変数と `getConfig()` 関数を削除
- `initConfig()` は直接 config オブジェクトを返すように変更

### テストの更新
- `local-file-storage.test.ts`: Config を直接コンストラクタに渡す形式に変更
- `ollama-llm-service.test.ts`: 同様の変更
- `in-memory-archive-session-manager.test.ts`: 同様の変更

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)