### PR TITLE
refactor(core): FileStorage の deprecated メソッドを削除

### DIFF
--- a/.ai-agent/tasks/20260207-remove-deprecated-file-storage-methods/README.md
+++ b/.ai-agent/tasks/20260207-remove-deprecated-file-storage-methods/README.md
@@ -1,0 +1,93 @@
+# FileStorage deprecated メソッド削除
+
+## 目的
+
+`FileStorage` インターフェースから deprecated メソッドを削除し、技術的負債を解消する。
+
+## 対象メソッド
+
+| メソッド | 代替 API | 使用箇所 |
+|---------|---------|----------|
+| `saveOriginalFromStream` | `saveFile` | テストコードのみ（mock 定義） |
+| `getAbsolutePath` | `readFile` / `readFileAsStream` | `caption-worker.ts` + テストコードの mock |
+
+## ゴール
+
+1. `caption-worker.ts` で `getAbsolutePath` を使用せず、バッファ経由でファイルを読み込む
+2. テストコードの mock から deprecated メソッドを削除
+3. `FileStorage` インターフェースと実装から deprecated メソッドを完全削除
+
+## 実装方針
+
+### 1. caption-worker.ts の修正
+
+現状:
+```typescript
+const absolutePath = fileStorage.getAbsolutePath(image.path);
+await ocrService.extractText(absolutePath);
+await captionService.generateWithContext(absolutePath, context);
+```
+
+変更後:
+```typescript
+const buffer = await fileStorage.readFile(image.path);
+await ocrService.extractTextFromBuffer(buffer);
+await captionService.generateFromBuffer(buffer); // with context
+```
+
+ただし、`CaptionService.generateWithContext` には `generateFromBuffer` ベースのオーバーロードがないため、新しいメソッド追加が必要:
+- `generateWithContextFromBuffer(buffer: Buffer, context: CaptionContext): Promise<CaptionResult>`
+
+### 2. CaptionService インターフェース拡張
+
+```typescript
+generateWithContextFromBuffer: (imageData: Buffer, context: CaptionContext) => Promise<CaptionResult>;
+```
+
+### 3. CaptionService 実装の修正
+
+`packages/core/src/infra/caption/` 配下の実装を更新。
+
+### 4. テストコードの mock 修正
+
+9 ファイル（core: 6、server: 3）の mock から deprecated メソッドを削除。
+
+### 5. FileStorage から deprecated メソッドを削除
+
+インターフェースと `LocalFileStorage` 実装の両方から削除。
+
+## 完了条件
+
+- [x] `caption-worker.ts` が `readFile` + バッファベース API を使用
+- [x] `CaptionService` に `generateWithContextFromBuffer` メソッドが追加されている
+- [x] テストの mock が新 API のみを定義
+- [x] `FileStorage` インターフェースから deprecated メソッドが削除されている
+- [x] `LocalFileStorage` から deprecated メソッドが削除されている
+- [x] 全テストが pass する
+- [x] 型チェックが通る
+
+## 作業ログ
+
+### 2026-02-07
+
+1. **CaptionService インターフェース拡張**
+   - `generateWithContextFromBuffer` メソッドを追加
+   - `TransformersCaptionService` に実装を追加
+
+2. **caption-worker.ts の修正**
+   - `getAbsolutePath` → `readFile` でバッファ取得
+   - `ocrService.extractText` → `extractTextFromBuffer`
+   - `captionService.generateWithContext` → `generateWithContextFromBuffer`
+
+3. **テスト mock の修正（9 ファイル）**
+   - `packages/core/tests/`: 6 ファイル
+   - `packages/server/tests/`: 3 ファイル
+   - `local-file-storage.test.ts` から deprecated メソッドのテストを削除
+
+4. **FileStorage インターフェース・実装から削除**
+   - `saveOriginalFromStream` を削除
+   - `getAbsolutePath` を削除
+
+5. **動作確認**
+   - `npm run typecheck`: パス
+   - `npm run test`: 全テストパス

--- a/packages/core/src/application/ports/caption-service.ts
+++ b/packages/core/src/application/ports/caption-service.ts
@@ -57,6 +57,16 @@ export interface CaptionService {
   generateWithContext: (imagePath: string, context: CaptionContext) => Promise<CaptionResult>;
 
   /**
+   * Generate a caption from image data with context from similar images.
+   * Uses an LLM to refine the caption based on similar images' descriptions.
+   * Falls back to generateFromBuffer if LLM is unavailable or context is empty.
+   * @param imageData - Raw image data as Buffer
+   * @param context - Context from similar images
+   * @returns The caption result
+   */
+  generateWithContextFromBuffer: (imageData: Buffer, context: CaptionContext) => Promise<CaptionResult>;
+
+  /**
    * Get the model identifier used by this service.
    */
   getModel: () => string;

--- a/packages/core/src/application/ports/file-storage.ts
+++ b/packages/core/src/application/ports/file-storage.ts
@@ -19,9 +19,6 @@ export interface FileStorage {
   saveFile: (stream: Readable, options: SaveFileOptions) => Promise<SaveFileResult>;
   saveFileFromBuffer: (buffer: Buffer, options: SaveFileOptions) => Promise<SaveFileResult>;
 
-  /** @deprecated saveFile を使用してください */
-  saveOriginalFromStream: (stream: Readable, extension: string) => Promise<SaveFileResult>;
-
   // --- 読み取り ---
   readFile: (relativePath: string) => Promise<Buffer>;
   readFileAsStream: (relativePath: string) => Promise<Readable>;
@@ -30,8 +27,4 @@ export interface FileStorage {
 
   // --- 削除 ---
   deleteFile: (relativePath: string) => Promise<void>;
-
-  // --- レガシー ---
-  /** @deprecated readFile/readFileAsStream を使用してください */
-  getAbsolutePath: (relativePath: string) => string;
 }

--- a/packages/core/src/infra/adapters/local-file-storage.ts
+++ b/packages/core/src/infra/adapters/local-file-storage.ts
@@ -122,14 +122,6 @@ export class LocalFileStorage implements FileStorage {
     };
   }
 
-  /** @deprecated saveFile を使用してください */
-  async saveOriginalFromStream(
-    stream: Readable,
-    extension: string,
-  ): Promise<SaveFileResult> {
-    return await this.saveFile(stream, { category: 'originals', extension });
-  }
-
   async readFile(relativePath: string): Promise<Buffer> {
     const filePath = this.resolveAndValidatePath(relativePath);
     return await readFile(filePath);
@@ -160,10 +152,5 @@ export class LocalFileStorage implements FileStorage {
   async deleteFile(relativePath: string): Promise<void> {
     const filePath = this.resolveAndValidatePath(relativePath);
     await unlink(filePath);
-  }
-
-  /** @deprecated readFile/readFileAsStream を使用してください */
-  getAbsolutePath(relativePath: string): string {
-    return this.resolveAndValidatePath(relativePath);
   }
 }

--- a/packages/core/src/infra/caption/transformers-caption-service.ts
+++ b/packages/core/src/infra/caption/transformers-caption-service.ts
@@ -185,6 +185,11 @@ export class TransformersCaptionService implements CaptionService {
   }
 
   async generateWithContext(imagePath: string, context: CaptionContext): Promise<CaptionResult> {
+    const imageData = await readFile(imagePath);
+    return await this.generateWithContextFromBuffer(imageData, context);
+  }
+
+  async generateWithContextFromBuffer(imageData: Buffer, context: CaptionContext): Promise<CaptionResult> {
     // Determine whether LLM is available (short-circuit if service is undefined)
     const llmAvailable
       = this.llmService !== undefined && await this.llmService.isAvailable();
@@ -195,11 +200,11 @@ export class TransformersCaptionService implements CaptionService {
 
     // If no context or LLM not available, fall back to basic generation
     if (!hasContext || !llmAvailable) {
-      return await this.generateFromFile(imagePath);
+      return await this.generateFromBuffer(imageData);
     }
 
     // First, generate a base caption using Florence-2
-    const baseResult = await this.generateFromFile(imagePath);
+    const baseResult = await this.generateFromBuffer(imageData);
 
     // Build the prompt for LLM refinement with similarity scores
     const similarDescriptionsText = context.similarDescriptions.length > 0

--- a/packages/core/src/infra/workers/caption-worker.ts
+++ b/packages/core/src/infra/workers/caption-worker.ts
@@ -63,14 +63,14 @@ export function createCaptionJobHandler(deps: {
     // 30% - ファイル確認完了
     await updateProgress(30);
 
+    // ファイルをバッファとして読み込み
+    const imageBuffer = await fileStorage.readFile(image.path);
+
     // OCR でテキストを抽出（オプション）
-    // NOTE: ocrService/captionService はパスベースのため getAbsolutePath を引き続き使用
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- OCR/Caption サービスのインターフェースがパスベースのため
-    const absolutePath = fileStorage.getAbsolutePath(image.path);
     let ocrText: string | undefined;
     if (ocrService !== undefined) {
       try {
-        const ocrResult = await ocrService.extractText(absolutePath);
+        const ocrResult = await ocrService.extractTextFromBuffer(imageBuffer);
         if (ocrResult.text.trim() !== '') {
           ocrText = ocrResult.text;
         }
@@ -96,7 +96,7 @@ export function createCaptionJobHandler(deps: {
     await updateProgress(50);
 
     // キャプション生成（重い処理）
-    const result = await captionService.generateWithContext(absolutePath, {
+    const result = await captionService.generateWithContextFromBuffer(imageBuffer, {
       similarDescriptions,
       ocrText,
     });

--- a/packages/core/tests/application/image/delete-image.test.ts
+++ b/packages/core/tests/application/image/delete-image.test.ts
@@ -46,13 +46,11 @@ function createMockFileStorage(
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn(),
     deleteFile: vi.fn().mockResolvedValue(undefined),
-    getAbsolutePath: vi.fn(path => `/absolute/${path}`),
     ...overrides,
   };
 }

--- a/packages/core/tests/application/image/upload-image.test.ts
+++ b/packages/core/tests/application/image/upload-image.test.ts
@@ -42,13 +42,11 @@ function createMockFileStorage(): FileStorage {
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn(),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn(),
   };
 }
 

--- a/packages/core/tests/application/url-crawl/import-from-url-crawl.test.ts
+++ b/packages/core/tests/application/url-crawl/import-from-url-crawl.test.ts
@@ -67,13 +67,11 @@ function createMockDeps() {
   const mockFileStorage: FileStorage = {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn(),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn(),
   };
 
   const mockImageProcessor: ImageProcessor = {

--- a/packages/core/tests/embedding/generate-embedding.test.ts
+++ b/packages/core/tests/embedding/generate-embedding.test.ts
@@ -61,13 +61,11 @@ function createMockDeps(): GenerateEmbeddingDeps {
   const mockFileStorage: FileStorage = {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn(),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn(),
   };
 
   const mockEmbeddingService: EmbeddingService = {

--- a/packages/core/tests/infra/adapters/local-file-storage.test.ts
+++ b/packages/core/tests/infra/adapters/local-file-storage.test.ts
@@ -37,59 +37,6 @@ describe('LocalFileStorage', () => {
     await rm(tempDir, { recursive: true });
   });
 
-  describe('saveOriginalFromStream', () => {
-    it('should save file from stream', async () => {
-      const content = 'test file content';
-      const stream = Readable.from(Buffer.from(content));
-
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-      const result = await storage.saveOriginalFromStream(stream, '.txt');
-
-      expect(result.filename).toMatch(/^[a-f0-9-]+\.txt$/);
-      expect(result.path).toBe(`originals/${result.filename}`);
-
-      // Verify file was saved
-      const savedPath = join(tempDir, result.path);
-      const savedContent = await readFile(savedPath, 'utf-8');
-      expect(savedContent).toBe(content);
-    });
-
-    it('should save image file with correct extension', async () => {
-      const stream = Readable.from(Buffer.from('fake image data'));
-
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-      const result = await storage.saveOriginalFromStream(stream, '.png');
-
-      expect(result.filename).toMatch(/^[a-f0-9-]+\.png$/);
-    });
-
-    it('should create originals directory if not exists', async () => {
-      const stream = Readable.from(Buffer.from('test'));
-
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-      const result = await storage.saveOriginalFromStream(stream, '.txt');
-
-      expect(result.path).toMatch(/^originals\//);
-    });
-
-    it('should clean up partial file on stream error', async () => {
-      // Create a stream that emits an error
-      const errorStream = new Readable({
-        read() {
-          this.push(Buffer.from('partial data'));
-          process.nextTick(() => {
-            this.destroy(new Error('Stream error'));
-          });
-        },
-      });
-
-      await expect(
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-        storage.saveOriginalFromStream(errorStream, '.txt'),
-      ).rejects.toThrow('Stream error');
-    });
-  });
-
   describe('deleteFile', () => {
     it('should delete existing file', async () => {
       // Create a file first
@@ -259,26 +206,6 @@ describe('LocalFileStorage', () => {
       const exists = await storage.fileExists('originals/non-existent.txt');
 
       expect(exists).toBe(false);
-    });
-  });
-
-  describe('getAbsolutePath', () => {
-    it('should return absolute path for relative path', () => {
-      const relativePath = 'originals/test.png';
-
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-      const result = storage.getAbsolutePath(relativePath);
-
-      expect(result).toBe(join(tempDir, relativePath));
-    });
-
-    it('should handle nested paths', () => {
-      const relativePath = 'thumbnails/2024/01/test.jpg';
-
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated メソッドのテスト
-      const result = storage.getAbsolutePath(relativePath);
-
-      expect(result).toBe(join(tempDir, relativePath));
     });
   });
 });

--- a/packages/core/tests/infra/workers/archive-import-worker.test.ts
+++ b/packages/core/tests/infra/workers/archive-import-worker.test.ts
@@ -36,13 +36,11 @@ function createMockFileStorage(): FileStorage {
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn(),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn(),
   };
 }
 

--- a/packages/server/tests/infra/http/controllers/image-controller.test.ts
+++ b/packages/server/tests/infra/http/controllers/image-controller.test.ts
@@ -62,13 +62,11 @@ function createMockFileStorage(): FileStorage {
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn().mockResolvedValue(true),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn().mockReturnValue('/tmp/test.png'),
   };
 }
 

--- a/packages/server/tests/infra/http/controllers/image-from-local.test.ts
+++ b/packages/server/tests/infra/http/controllers/image-from-local.test.ts
@@ -55,13 +55,11 @@ function createMockFileStorage(): FileStorage {
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn().mockResolvedValue(true),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn().mockReturnValue('/tmp/test.png'),
   };
 }
 

--- a/packages/server/tests/infra/http/controllers/image-suggestion-controller.test.ts
+++ b/packages/server/tests/infra/http/controllers/image-suggestion-controller.test.ts
@@ -92,13 +92,11 @@ function createMockFileStorage(): FileStorage {
   return {
     saveFile: vi.fn(),
     saveFileFromBuffer: vi.fn(),
-    saveOriginalFromStream: vi.fn(),
     readFile: vi.fn(),
     readFileAsStream: vi.fn(),
     getFileSize: vi.fn(),
     fileExists: vi.fn().mockResolvedValue(true),
     deleteFile: vi.fn(),
-    getAbsolutePath: vi.fn().mockReturnValue('/tmp/test.png'),
   };
 }
 


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

`FileStorage` インターフェースに残っていた deprecated メソッド（`saveOriginalFromStream`, `getAbsolutePath`）を削除し、技術的負債を解消する。

Closes #177

## 変更概要

### 1. CaptionService インターフェース拡張
- `generateWithContextFromBuffer(imageData: Buffer, context: CaptionContext)` メソッドを追加
- `TransformersCaptionService` に実装を追加

### 2. caption-worker.ts の修正
- `getAbsolutePath` → `readFile` でバッファ取得に変更
- OCR: `extractText(path)` → `extractTextFromBuffer(buffer)`
- Caption: `generateWithContext(path, ...)` → `generateWithContextFromBuffer(buffer, ...)`

### 3. テスト mock の修正（9 ファイル）
- `packages/core/tests/`: 6 ファイル
- `packages/server/tests/`: 3 ファイル
- `local-file-storage.test.ts` から deprecated メソッドのテストを削除

### 4. FileStorage インターフェース・実装から削除
- `saveOriginalFromStream` を削除
- `getAbsolutePath` を削除

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)