### PR TITLE
chore: pre-commit から prek へ移行

### DIFF
--- a/.ai-agent/tasks/20260202-fix-cc-edit-lint-hook/README.md
+++ b/.ai-agent/tasks/20260202-fix-cc-edit-lint-hook/README.md
@@ -35,14 +35,14 @@
 ## 完了条件
 
 - [ ] `cc-edit-lint-hook.mjs` の環境変数名が ESLint 設定と一致している
-- [ ] `DISABLED_FIXED_RULES=true` が pre-commit 経由で ESLint に正しく伝播する
+- [ ] `DISABLED_FIXED_RULES=true` が prek 経由で ESLint に正しく伝播する
 - [ ] `SKIP_LINT_HOOK=true` で hook 全体をスキップできる
 - [ ] 通常のファイル編集時は従来通り ESLint --fix が動作する
 
 ## 完了条件チェック
 
 - [x] `cc-edit-lint-hook.mjs` の環境変数名が ESLint 設定と一致している
-- [x] `DISABLED_FIXED_RULES=true` が pre-commit 経由で ESLint に正しく伝播する
+- [x] `DISABLED_FIXED_RULES=true` が prek 経由で ESLint に正しく伝播する
 - [x] `SKIP_LINT_HOOK=true` で hook 全体をスキップできる
 - [x] 通常のファイル編集時は従来通り ESLint --fix が動作する
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Build
         run: devenv shell npm run build
 
-      - name: pre-commit run
-        run: devenv shell pre-commit run --all-files --verbose
+      - name: Lint
+        run: devenv shell prek run --all-files --verbose
 
       - name: Show modified files
         if: failure()

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1769947633,
+        "lastModified": 1770399425,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "270581b84ab2957123f140e18d4189b904325e2b",
+        "rev": "0f006b2e9f591cc44cf219048b5e33793530403b",
         "type": "github"
       },
       "original": {
@@ -73,17 +73,37 @@
       }
     },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1767052823,
+        "lastModified": 1770434727,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "538a5124359f0b3d466e1160378c87887e3b51a4",
+        "rev": "8430f16a39c27bdeef236f1eeb56f0b51b33d348",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "ref": "rolling",
         "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769922788,
+        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -16,30 +16,33 @@
   };
 
   # https://devenv.sh/scripts/
+  scripts.lint-all.exec = ''
+    prek run --all-files
+  '';
   scripts.cc-edit-lint-hook.exec = ''
     "$DEVENV_ROOT/scripts/cc-edit-lint-hook.mjs"
   '';
 
   # https://devenv.sh/git-hooks/
-  git-hooks.hooks.npx-eslint-pkg-eslint-config = {
+  git-hooks.hooks.npx-eslint-pkg-api = {
     enable = true;
-    entry = "./scripts/run-script.mjs --cwd packages/eslint-config -- npx eslint --cache --fix FILES";
-    files = "^packages/eslint-config/.*\.[cm]?(js|ts)x?$";
-  };
-  git-hooks.hooks.npx-eslint-pkg-e2e-test = {
-    enable = true;
-    entry = "./scripts/run-script.mjs --cwd packages/e2e-test -- npx eslint --cache --fix FILES";
-    files = "^packages/e2e-test/.*\.[cm]?(js|ts)x?$";
+    entry = "./scripts/run-script.mjs --cwd packages/api -- npx eslint --cache --fix FILES";
+    files = "^packages/api/.*\.[cm]?(js|ts)x?$";
   };
   git-hooks.hooks.npx-eslint-pkg-core = {
     enable = true;
     entry = "./scripts/run-script.mjs --cwd packages/core -- npx eslint --cache --fix FILES";
     files = "^packages/core/.*\.[cm]?(js|ts)x?$";
   };
-  git-hooks.hooks.npx-eslint-pkg-api = {
+  git-hooks.hooks.npx-eslint-pkg-desktop-app = {
     enable = true;
-    entry = "./scripts/run-script.mjs --cwd packages/api -- npx eslint --cache --fix FILES";
-    files = "^packages/api/.*\.[cm]?(js|ts)x?$";
+    entry = "./scripts/run-script.mjs --cwd packages/desktop-app -- npx eslint --cache --fix FILES";
+    files = "^packages/desktop-app/.*\.[cm]?(js|ts)x?$";
+  };
+  git-hooks.hooks.npx-eslint-pkg-eslint-config = {
+    enable = true;
+    entry = "./scripts/run-script.mjs --cwd packages/eslint-config -- npx eslint --cache --fix FILES";
+    files = "^packages/eslint-config/.*\.[cm]?(js|ts)x?$";
   };
   git-hooks.hooks.npx-eslint-pkg-server = {
     enable = true;
@@ -50,11 +53,6 @@
     enable = true;
     entry = "./scripts/run-script.mjs --cwd packages/web-client -- npx eslint --cache --fix FILES";
     files = "^packages/web-client/.*\.[cm]?(js|ts)x?$";
-  };
-  git-hooks.hooks.npx-eslint-pkg-desktop-app = {
-    enable = true;
-    entry = "./scripts/run-script.mjs --cwd packages/desktop-app -- npx eslint --cache --fix FILES";
-    files = "^packages/desktop-app/.*\.[cm]?(js|ts)x?$";
   };
   git-hooks.hooks.npx-prisma-lint-pkg-core = {
     enable = true;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:client": "npm run dev -w @picstash/web-client",
     "dev:server": "npm run dev -w @picstash/server",
     "dev:ollama": "ollama serve || true",
-    "lint": "pre-commit run --all-files && npm run lint:deps",
+    "lint": "prek run --all-files && npm run lint:deps",
     "lint:deps": "npm run lint:deps --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "build": "npm run build -w @picstash/api -w @picstash/eslint-config && npm run build -w @picstash/core && npm run build -w @picstash/server -w @picstash/web-client",

--- a/scripts/cc-edit-lint-hook.mjs
+++ b/scripts/cc-edit-lint-hook.mjs
@@ -49,7 +49,7 @@ function gitRmCached(files, cwd) {
 
 function runPreCommit(cwd) {
   return new Promise((resolve) => {
-    const child = spawn("pre-commit", ["run"], {
+    const child = spawn("prek", ["run"], {
       stdio: "inherit",
       shell: process.platform === "win32",
       cwd,
@@ -60,7 +60,7 @@ function runPreCommit(cwd) {
     });
 
     child.on("error", (err) => {
-      console.error(`Error: Failed to execute pre-commit: ${err.message}`);
+      console.error(`Error: Failed to execute prek: ${err.message}`);
       resolve(1);
     });
 


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

pre-commit ツールを prek に置き換えることで、開発環境のリンターツールを統一する。

## 変更概要

- CI ワークフロー（`.github/workflows/ci-lint.yml`）で prek を使用するよう変更
- `package.json` の lint スクリプトで prek を使用
- `cc-edit-lint-hook.mjs` で prek コマンドを使用
- `devenv.nix` に `lint-all` スクリプトを追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)