### PR TITLE
ci: desktop-app インストーラービルドの CD ワークフローを追加

### DIFF
--- a/.ai-agent/tasks/20260207-desktop-app-cd-workflow/README.md
+++ b/.ai-agent/tasks/20260207-desktop-app-cd-workflow/README.md
@@ -1,0 +1,50 @@
+# desktop-app のインストーラー CD ワークフロー作成
+
+## 目的・ゴール
+
+GitHub Actions で desktop-app のインストーラー（dmg / exe / AppImage / deb）をビルドし、artifact として保存する CD ワークフローを作成する。
+
+## 現状分析
+
+### 既存のワークフロー
+- `ci-test.yml`: テスト・E2E 実行
+- `ci-lint.yml`: リント・型チェック
+
+### desktop-app のビルド設定
+- `electron-builder.json` で各プラットフォーム用のビルド設定が既に存在
+  - **macOS**: dmg (x64, arm64)
+  - **Windows**: nsis (x64)
+  - **Linux**: AppImage (x64), deb (x64)
+- `npm run package` で `electron-builder` が実行される
+
+## 実装方針
+
+### 1. 新規ワークフローファイル作成
+`.github/workflows/cd-desktop-release.yml` を作成
+
+### 2. トリガー条件
+- **手動実行**: `workflow_dispatch` で任意のタイミングでビルド可能
+
+### 3. ビルド対象プラットフォーム
+マトリックス戦略を使用して各 OS でビルド:
+- **macOS** (macos-latest): dmg (x64, arm64)
+- **Windows** (windows-latest): nsis installer (x64)
+- **Linux** (ubuntu-latest): AppImage, deb (x64)
+
+### 4. アーティファクト保存
+各プラットフォームのインストーラーを GitHub Artifacts として保存
+
+## 完了条件
+
+- [ ] CD ワークフローが正常に動作する
+- [ ] 各プラットフォーム（macOS / Windows / Linux）でビルドが成功する
+- [ ] 生成されたインストーラーが artifact として保存される
+- [ ] 手動実行でトリガーできる
+
+## 作業ログ
+
+### 2026-02-07
+- `.github/workflows/cd-desktop-release.yml` を作成
+  - `workflow_dispatch` による手動実行のみ
+  - マトリックス戦略で macOS / Windows / Linux を並列ビルド
+  - 各プラットフォームのインストーラーを artifact として保存（30日間保持）

--- a/.github/workflows/cd-desktop-release.yml
+++ b/.github/workflows/cd-desktop-release.yml
@@ -1,0 +1,45 @@
+name: CD Desktop Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build desktop app (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            artifact-name: desktop-app-macos
+            artifact-path: packages/desktop-app/release/*.dmg
+          - os: windows-latest
+            artifact-name: desktop-app-windows
+            artifact-path: packages/desktop-app/release/*.exe
+          - os: ubuntu-latest
+            artifact-name: desktop-app-linux
+            artifact-path: |
+              packages/desktop-app/release/*.AppImage
+              packages/desktop-app/release/*.deb
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-node
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Package desktop app
+        run: npm run package -w @picstash/desktop-app
+
+      - name: Upload installer
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
+          retention-days: 30


### PR DESCRIPTION
## 目的

desktop-app のインストーラーを GitHub Actions でビルドし、artifact として保存できるようにする。

## 変更概要

- `.github/workflows/cd-desktop-release.yml` を追加
  - `workflow_dispatch` による手動実行のみ
  - マトリックス戦略で macOS / Windows / Linux を並列ビルド
  - 各プラットフォームのインストーラーを artifact として保存（30日間保持）

### 生成される artifact

| OS | artifact 名 | 内容 |
|----|-------------|------|
| macOS | `desktop-app-macos` | dmg (x64, arm64) |
| Windows | `desktop-app-windows` | exe |
| Linux | `desktop-app-linux` | AppImage, deb |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)