### PR TITLE
fix: macOS pkg の isRelocatable を無効化

### DIFF
--- a/packages/desktop-app/electron-builder.json
+++ b/packages/desktop-app/electron-builder.json
@@ -20,6 +20,9 @@
       }
     ]
   },
+  "pkg": {
+    "isRelocatable": false
+  },
   "win": {
     "target": [
       {


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

macOS の pkg インストーラーでアプリをインストールした際、「インストール完了」と表示されるにもかかわらず `/Applications` にアプリが見つからない問題を修正する。

## 変更概要

- `electron-builder.json` に `pkg.isRelocatable: false` を追加
- macOS インストーラーの「リロケーション」機能を無効化し、常に `/Applications` にインストールされるようにする

### 背景

macOS のインストーラーには「リロケーション」機能があり、システム上に同じアプリが存在する場合、その場所にインストールしようとします。ビルドディレクトリに `.app` が残っている状態で pkg をインストールすると、`/Applications` ではなくビルドディレクトリにインストールされてしまっていました。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)