### PR TITLE
fix: @picstash/core の exports に package.json を追加

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "npm run db:generate && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

desktop-app を起動する際に以下のエラーが発生する問題を修正:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /Users/mizunashi/Workspace/MyWork/picstash/node_modules/@picstash/core/package.json
```

## 変更概要

- `@picstash/core` の `package.json` の `exports` フィールドに `./package.json` を追加
- `migration-runner.ts` が `require.resolve('@picstash/core/package.json')` でパスを解決できるようにした

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)