### PR TITLE
fix: release workflow から package.json のバージョン更新を削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,19 +45,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update version in package.json
-        run: |
-          npm version ${{ inputs.version }} --no-git-tag-version --workspaces --include-workspace-root
-
-      - name: Commit version update
-        run: |
-          git add -A
-          git commit -m "chore: bump version to ${{ inputs.version }}"
-
       - name: Create and push tag
         run: |
           git tag v${{ inputs.version }}
-          git push origin HEAD:${{ github.ref_name }}
           git push origin v${{ inputs.version }}
 
   build:


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

リリースワークフローで `npm version` による package.json の更新が不要なため、シンプルにタグの作成のみ行うように修正します。

## 変更概要

- `npm version` による package.json のバージョン更新ステップを削除
- バージョン更新コミットのステップを削除
- ブランチへのプッシュ（`git push origin HEAD`）を削除し、タグのプッシュのみに変更

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)