### PR TITLE
feat(desktop-app): Storybook stories を追加

### DIFF
--- a/.ai-agent/tasks/20260208-expand-desktop-storybook/README.md
+++ b/.ai-agent/tasks/20260208-expand-desktop-storybook/README.md
@@ -1,0 +1,70 @@
+# desktop-app の Storybook 対応拡大
+
+## 目的・ゴール
+
+desktop-app の UI コンポーネントに Storybook stories を追加し、コンポーネントのテスト・ドキュメント化を強化する。
+
+## 現状
+
+現在 desktop-app には 2 つの stories ファイルのみ：
+- `LabelBadge.stories.tsx`
+- `SettingsPageView.stories.tsx`
+
+一方 web-client には 26 個の stories がある。
+
+## 実装方針
+
+### 優先順位
+
+1. **純粋なView コンポーネント（props のみ依存）** - Storybook 向き
+   - `ImageDropzoneView` - props のみ依存
+   - `LabelForm` - props のみ依存
+   - `LabelList` - props のみ依存（内部で useState 使用）
+
+2. **API/hooks 依存コンポーネント** - View 分離が必要
+   - `SearchBar` - useApiClient, useQuery 使用 → View 分離必要
+   - `AppLayout` - useLocation 使用 → View 分離 or MemoryRouter でラップ
+
+### 対象コンポーネント（Phase 1）
+
+| コンポーネント | ファイル | 対応方法 |
+|-------------|---------|---------|
+| ImageDropzoneView | features/upload/components | そのまま stories 作成 |
+| LabelForm | features/labels/components | そのまま stories 作成 |
+| LabelList | features/labels/components | そのまま stories 作成 |
+
+### 対象コンポーネント（Phase 2 - 要View分離）
+
+| コンポーネント | ファイル | 対応方法 |
+|-------------|---------|---------|
+| AppLayout | shared/components | View 分離 or MemoryRouter ラップ |
+| SearchBar | features/gallery/components | SearchBarView 分離 |
+
+## 完了条件
+
+- [x] ImageDropzoneView.stories.tsx 作成
+- [x] LabelForm.stories.tsx 作成
+- [x] LabelList.stories.tsx 作成
+- [x] Storybook が正常に起動し、stories が表示される
+- [x] テスト通過（npm test）
+
+## 作業ログ
+
+### 2026-02-08
+
+1. **現状分析**
+   - desktop-app: 2 stories（LabelBadge, SettingsPageView）
+   - web-client: 26 stories
+
+2. **Phase 1 実装（純粋 View コンポーネント）**
+   - `ImageDropzoneView.stories.tsx` 作成（5 stories）
+   - `LabelForm.stories.tsx` 作成（7 stories）
+   - `LabelList.stories.tsx` 作成（7 stories）
+
+3. **Storybook 設定修正**
+   - `.storybook/main.ts` に `viteFinal` を追加してパスエイリアス（`@/`）を設定
+   - ESM 対応のため `import.meta.url` を使用
+
+4. **テスト結果**
+   - Storybook テスト: 29 tests passed
+   - ユニットテスト: 62 tests passed

--- a/packages/desktop-app/.storybook/main.ts
+++ b/packages/desktop-app/.storybook/main.ts
@@ -1,9 +1,25 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rendererSrc = resolve(currentDir, '../src/renderer');
 
 const config: StorybookConfig = {
   stories: ['../src/renderer/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   framework: '@storybook/react-vite',
   addons: ['@storybook/addon-vitest'],
+  viteFinal: async (viteConfig) => {
+    return {
+      ...viteConfig,
+      resolve: {
+        ...viteConfig.resolve,
+        alias: {
+          '@': rendererSrc,
+        },
+      },
+    };
+  },
 };
 
 export default config;

--- a/packages/desktop-app/src/renderer/features/labels/components/LabelForm.stories.tsx
+++ b/packages/desktop-app/src/renderer/features/labels/components/LabelForm.stories.tsx
@@ -1,0 +1,130 @@
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { LabelForm } from './LabelForm';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Features/Labels/LabelForm',
+  component: LabelForm,
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+} satisfies Meta<typeof LabelForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockLabel = {
+  id: '1',
+  name: 'キャラクター',
+  color: '#e64980',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+export const CreateMode: Story = {
+  args: {
+    mode: 'create',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // フォームが表示されていることを確認
+    await expect(canvas.getByRole('textbox', { name: /ラベル名/ })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('カラー')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'ラベルを作成' })).toBeInTheDocument();
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    mode: 'edit',
+    label: mockLabel,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 既存の値が入力されていることを確認
+    await expect(canvas.getByLabelText('ラベル名')).toHaveValue('キャラクター');
+    await expect(canvas.getByRole('button', { name: 'ラベルを更新' })).toBeInTheDocument();
+  },
+};
+
+export const WithExistingColors: Story = {
+  args: {
+    mode: 'create',
+    existingColors: ['#e03131', '#f76707', '#fab005'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // フォームが表示されていることを確認
+    await expect(canvas.getByRole('textbox', { name: /ラベル名/ })).toBeInTheDocument();
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    mode: 'create',
+    isSubmitting: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // フォームが無効化されていることを確認
+    await expect(canvas.getByRole('textbox', { name: /ラベル名/ })).toBeDisabled();
+  },
+};
+
+export const CreateLabelInteraction: Story = {
+  args: {
+    mode: 'create',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // 名前を入力
+    const nameInput = canvas.getByRole('textbox', { name: /ラベル名/ });
+    await userEvent.type(nameInput, '新しいラベル');
+
+    // 名前が入力されていることを確認
+    await expect(nameInput).toHaveValue('新しいラベル');
+
+    // フォームを送信
+    const submitButton = canvas.getByRole('button', { name: 'ラベルを作成' });
+    await userEvent.click(submitButton);
+
+    // onSubmit が呼ばれていることを確認
+    await expect(args.onSubmit).toHaveBeenCalled();
+  },
+};
+
+export const CancelInteraction: Story = {
+  args: {
+    mode: 'edit',
+    label: mockLabel,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // キャンセルボタンをクリック
+    const cancelButton = canvas.getByRole('button', { name: 'キャンセル' });
+    await userEvent.click(cancelButton);
+
+    // onCancel が呼ばれていることを確認
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+export const ValidationDisabledWhenEmpty: Story = {
+  args: {
+    mode: 'create',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 名前が空の場合、送信ボタンが無効化されていることを確認
+    const submitButton = canvas.getByRole('button', { name: 'ラベルを作成' });
+    await expect(submitButton).toBeDisabled();
+  },
+};

--- a/packages/desktop-app/src/renderer/features/labels/components/LabelList.stories.tsx
+++ b/packages/desktop-app/src/renderer/features/labels/components/LabelList.stories.tsx
@@ -1,0 +1,139 @@
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { LabelList } from './LabelList';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Features/Labels/LabelList',
+  component: LabelList,
+  args: {
+    onUpdate: fn(async () => { await Promise.resolve(); }),
+    onDelete: fn(async () => { await Promise.resolve(); }),
+  },
+} satisfies Meta<typeof LabelList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockLabels = [
+  {
+    id: '1',
+    name: 'キャラクター',
+    color: '#e64980',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: '2',
+    name: '背景',
+    color: '#228be6',
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+  },
+  {
+    id: '3',
+    name: '風景',
+    color: '#40c057',
+    createdAt: '2026-01-03T00:00:00.000Z',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    labels: mockLabels,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 全てのラベルが表示されていることを確認
+    await expect(canvas.getByText('キャラクター')).toBeInTheDocument();
+    await expect(canvas.getByText('背景')).toBeInTheDocument();
+    await expect(canvas.getByText('風景')).toBeInTheDocument();
+
+    // 編集・削除ボタンが表示されていることを確認
+    await expect(canvas.getAllByRole('button', { name: /を編集/ })).toHaveLength(3);
+    await expect(canvas.getAllByRole('button', { name: /を削除/ })).toHaveLength(3);
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    labels: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 空状態のメッセージが表示されていることを確認
+    await expect(canvas.getByText('ラベルがまだありません。上のフォームで作成してください。')).toBeInTheDocument();
+  },
+};
+
+export const SingleLabel: Story = {
+  args: {
+    labels: [mockLabels[0]!],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 1つのラベルが表示されていることを確認
+    await expect(canvas.getByText('キャラクター')).toBeInTheDocument();
+  },
+};
+
+export const OpenEditModal: Story = {
+  args: {
+    labels: mockLabels,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 編集ボタンをクリック
+    const editButtons = canvas.getAllByRole('button', { name: /を編集/ });
+    const firstEditButton = editButtons[0];
+    if (firstEditButton !== undefined) {
+      await userEvent.click(firstEditButton);
+    }
+
+    // モーダルが開いていることを確認（ドキュメント全体を検索）
+    const modal = within(document.body);
+    await waitFor(async () => {
+      await expect(modal.getByText('ラベルを編集')).toBeInTheDocument();
+    });
+  },
+};
+
+export const OpenDeleteModal: Story = {
+  args: {
+    labels: mockLabels,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 削除ボタンをクリック
+    const deleteButtons = canvas.getAllByRole('button', { name: /を削除/ });
+    const firstDeleteButton = deleteButtons[0];
+    if (firstDeleteButton !== undefined) {
+      await userEvent.click(firstDeleteButton);
+    }
+
+    // 削除確認モーダルが開いていることを確認（ドキュメント全体を検索）
+    const modal = within(document.body);
+    await waitFor(async () => {
+      await expect(modal.getByText('このラベルを削除しますか？')).toBeInTheDocument();
+    });
+  },
+};
+
+export const Updating: Story = {
+  args: {
+    labels: mockLabels,
+    isUpdating: true,
+  },
+};
+
+export const Deleting: Story = {
+  args: {
+    labels: mockLabels,
+    isDeleting: true,
+  },
+};

--- a/packages/desktop-app/src/renderer/features/upload/components/ImageDropzoneView.stories.tsx
+++ b/packages/desktop-app/src/renderer/features/upload/components/ImageDropzoneView.stories.tsx
@@ -1,0 +1,86 @@
+import { expect, fn, within } from 'storybook/test';
+import { ImageDropzoneView } from './ImageDropzoneView';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Features/Upload/ImageDropzoneView',
+  component: ImageDropzoneView,
+  args: {
+    onDrop: fn(),
+  },
+} satisfies Meta<typeof ImageDropzoneView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // デフォルトのテキストが表示されていることを確認
+    await expect(canvas.getByText('ここに画像をドラッグ＆ドロップ')).toBeInTheDocument();
+    await expect(canvas.getByText('またはクリックしてファイルを選択')).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isPending: true,
+    isError: false,
+    isSuccess: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // テキストが表示されていることを確認
+    await expect(canvas.getByText('ここに画像をドラッグ＆ドロップ')).toBeInTheDocument();
+  },
+};
+
+export const Success: Story = {
+  args: {
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 成功メッセージが表示されていることを確認
+    await expect(canvas.getByText('アップロード完了')).toBeInTheDocument();
+  },
+};
+
+export const Error: Story = {
+  args: {
+    isPending: false,
+    isError: true,
+    isSuccess: false,
+    errorMessage: 'ファイルサイズが大きすぎます',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // エラーメッセージが表示されていることを確認
+    await expect(canvas.getByText('ファイルサイズが大きすぎます')).toBeInTheDocument();
+  },
+};
+
+export const ErrorWithDefaultMessage: Story = {
+  args: {
+    isPending: false,
+    isError: true,
+    isSuccess: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // デフォルトエラーメッセージが表示されていることを確認
+    await expect(canvas.getByText('エラーが発生しました')).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
<!-- @copilot レビューは日本語で行ってください -->

## 目的

desktop-app の UI コンポーネントに Storybook stories を追加し、コンポーネントのテスト・ドキュメント化を強化する。

現状 desktop-app には 2 つの stories ファイル（LabelBadge, SettingsPageView）のみで、web-client（26 stories）と比較して対応が遅れていた。

## 変更概要

### 追加した Stories

- `ImageDropzoneView.stories.tsx` - 5 stories
  - Default, Loading, Success, Error, ErrorWithDefaultMessage
- `LabelForm.stories.tsx` - 7 stories
  - CreateMode, EditMode, WithExistingColors, Submitting, CreateLabelInteraction, CancelInteraction, ValidationDisabledWhenEmpty
- `LabelList.stories.tsx` - 7 stories
  - Default, Empty, SingleLabel, OpenEditModal, OpenDeleteModal, Updating, Deleting

### Storybook 設定修正

- `.storybook/main.ts` に `viteFinal` を追加してパスエイリアス（`@/`）を設定
- これにより `@/shared/di` などのインポートが正しく解決されるようになった

### テスト結果

- Storybook テスト: 29 tests passed（5 ファイル）
- ユニットテスト: 62 tests passed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)